### PR TITLE
Use mini-language for cut ami

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ shelf.db
 *.swp
 start_alton.sh
 ENV
+redis.conf
+dump.rdb

--- a/plugins/show.py
+++ b/plugins/show.py
@@ -123,7 +123,7 @@ class ShowPlugin(WillPlugin):
     def diff_ami_ids(self, message, first_ami, second_ami):
         self._diff_amis(first_ami, second_ami, message)
 
-    @respond_to("^(?P<body>cut\s+ami\s+for.*)")
+    @respond_to("^(?P<body>cut\s+ami.*)")
     def cut_from_edp(self, message, body):
         """
         cut ami for [e-d-p] from [e-d-p] with [var1=version var2=version ...] : Build an AMI for one EDP using the versions from a different EDP with verions overrides
@@ -132,8 +132,9 @@ class ShowPlugin(WillPlugin):
             parsed = self._parse_cut_ami(body)
         except ParseException as e:
             self._say_error('Invalid syntax for "cut ami": ' + repr(e))
+            return
 
-        dest_env, dest_dep, dest_play, source_env, source_dep, source_play, base_ami, version_overrides = (
+        dest_env, dest_dep, dest_play, source_env, source_dep, source_play, base_ami, version_overrides, verbose, noop = (
             parsed['dest_env'], parsed['dest_dep'], parsed['dest_play'], parsed['source_env'], parsed['source_dep'],
             parsed['source_play'], parsed['base_ami'], parsed['version_overrides'], parsed['verbose'], parsed['noop']
         )
@@ -212,8 +213,8 @@ class ShowPlugin(WillPlugin):
                 "from {source_env}-{source_dep}-{source_play}")
             if version_overrides:
                 example_command += (
-                    " with " + version_overrides +
-                    "configuration_secure=master")
+                    " with " + ' '.join('{}={}'.format(k,v) for k,v in version_overrides.items()) +
+                    " configuration_secure=master")
             else:
                 example_command += " with configuration_secure=master"
             example_command = example_command.format(

--- a/plugins/tests/test_show.py
+++ b/plugins/tests/test_show.py
@@ -112,7 +112,7 @@ class TestCutFromEdp(unittest.TestCase):
     @mock.patch.object(ShowPlugin, '__init__', return_value=None)   #uses boto
     @mock.patch.object(ShowPlugin, '_ami_for_edp', return_value='ami-00000000') #uses boto
     @mock.patch.object(ShowPlugin, '_notify_abbey')     #this is how we test the result
-    def test_result(self, mocked_notify_abbey, *args):
+    def test_complex_result(self, mocked_notify_abbey, *args):
         message = mock.Mock()
         show_plugin = ShowPlugin()
         body = "verbose noop cut ami for foo-bar-baz from one-two-three using ami-deadbeef with thing=athing bang=abang"
@@ -135,3 +135,23 @@ class TestCutFromEdp(unittest.TestCase):
             [final_versions.configuration, final_versions.configuration_secure,
             final_versions.play_versions, final_versions.repos]
         )
+
+    @mock.patch.object(ShowPlugin, 'say')   #uses hipchat connection
+    @mock.patch.object(ShowPlugin, '__init__', return_value=None)   #uses boto
+    @mock.patch.object(ShowPlugin, '_ami_for_edp', return_value='ami-00000000') #uses boto
+    @mock.patch.object(ShowPlugin, '_get_ami_versions', return_value = Versions(    #uses boto
+        'CONFIG REF', 'CONFIG_SECURE REF', {'thing': 'someotherthing', 'bang': 'someotherbang'},
+        {'thing': {'url': 'THINGURL', 'shorthash': 'THINGSHORTHASH'},
+         'bang':  {'url': 'BANGURL',  'shorthash': 'BANGSHORTHASH'}}
+    ))
+    @mock.patch.object(ShowPlugin, '_notify_abbey')     #this is how we test the result
+    def test_basic_result(self, mocked_notify_abbey, mocked_get_ami_versions, *args):
+        message = mock.Mock()
+        show_plugin = ShowPlugin()
+        body = "cut ami for foo-bar-baz from one-two-three"
+
+        show_plugin.cut_from_edp(message, body)
+        #spec: self._notify_abbey(message, dest_env, dest_dep, dest_play,
+        #    final_versions, noop, dest_running_ami, verbose)
+        mocked_notify_abbey.assert_called_with(message, 'foo', 'bar', 'baz',
+            mocked_get_ami_versions.return_value, False, 'ami-00000000', False)

--- a/plugins/tests/test_show.py
+++ b/plugins/tests/test_show.py
@@ -1,0 +1,102 @@
+# To run these, go to the `plugins` directory and run `python -m unittest discover`
+
+from show import *
+from pyparsing import ParseException
+import unittest
+
+class TestParseCutAmi(unittest.TestCase):
+    valid = [
+        {'text': 'cut ami for one-two-three from foo-bar-baz',
+         'msg' : 'basic syntax check failed'},
+        {'text': 'cut ami for prod_a-edx_b-programs_c from stage_1-edx_2-programs_3',
+         'msg' : 'some valid character(s) not allowed in e-d-c identifier'},
+        {'text': 'cut ami for prod-edx-programs from stage-edx-programs using ami-deadbeef',
+         'msg' : '"using" statement failed'},
+        {'text': 'cut ami for prod-edx-edxapp from stage-edx-edxapp with configuration=master',
+         'msg' : '"with" statement failed'},
+        {'text': 'cut ami for foo-bar-baz from one-two-three with foo=bar bing=baz',
+         'msg' : 'multiple overrides in "with" statement failed'},
+        {'text': 'cut ami for foo-bar-baz from one-two-three with foo =bar bing= baz',
+         'msg' : 'using spaces in "with" statement overrides should be permitted'},
+        {'text': 'cut ami for prod-edx-programs from stage-edx-programs using ami-deadbeef with configuration=master configuration_secure=master programs_version=master',
+         'msg' : '''using both "using" and "with" statements failed or they're not order-independent'''},
+        {'text': 'cut ami for prod-edx-programs from stage-edx-programs with configuration=master configuration_secure=master programs_version=master using ami-deadbeef',
+         'msg' : '''using both "using" and "with" statements failed or they're not order-independent'''},
+        {'text': 'verbose cut ami for prod-edx-programs from stage-edx-programs',
+         'msg' : '"verbose" option failed'},
+        {'text': 'noop cut ami for prod-edx-programs from stage-edx-programs',
+         'msg' : '"noop" option failed'},
+        {'text': 'noop verbose cut ami for prod-edx-programs from stage-edx-programs',
+         'msg' : '''using both "noop" and "verbose" options failed or they're not order-independent'''},
+        {'text': 'verbose noop cut ami for prod-edx-programs from stage-edx-programs',
+         'msg' : '''using both "noop" and "verbose" options failed or they're not order-independent'''},
+    ]
+
+    def test_valid(self):
+        for test in self.valid:
+            try:
+                ShowPlugin._parse_cut_ami(test['text'])
+            except ParseException as e:
+                self.fail('Parsing failed for string: `{}` error: `{}` message: `{}`'.format(
+                    test['text'], e.message, test['msg']))
+
+
+    invalid = [
+        {'text': 'cut ami for prod -edx-edxapp from stage-edx-  programs',
+         'msg' : 'spaces should not be allowed in an e-d-p'},
+        {'text': 'cut ami for foo-bar-baz from one-two-three using esdewfeokjsd',
+         'msg' : 'invalid AMI string allowed (should be "ami-" + 8 hex chars)'},
+        {'text': 'cut ami for foo-bar-baz from one-two-three using ami-jklmnopq',
+         'msg' : 'invalid characters allowed in AMI ID (hex chars only)'},
+        {'text': 'cut ami for foo-bar-baz from one-two-three using ami-deadbeef1',
+         'msg' : 'allowed AMI ID that was too long (8 characters expected)'},
+        {'text': 'cut ami for foo-bar-baz from one-two-three using ami-deadbee',
+         'msg' : 'allowed AMI ID that was too short (8 characters expected)'},
+
+        #These'll succeed until pyparsing 2.0.6 <http://sourceforge.net/p/pyparsing/code/296/>
+        # {'text': 'cut ami for prod-edge-programs from stage-edx-programs using ami-deadbeef using ami-00000000',
+        #  'msg' : 'allowed multiple "using" statments'},
+        # {'text': 'cut ami for prod-edge-programs from prod-edge-programs with foo=bar with bing=baz',
+        #  'msg' : 'allowed multiple "with" statements'},
+    ]
+
+    def test_invalid(self):
+        for test in self.invalid:
+            try:
+                ShowPlugin._parse_cut_ami(test['text'])
+                self.fail('Parsing erroneously succeeded for string `{}`: {}'.format(
+                    test['text'], test['msg']))
+            except:
+                pass
+
+    def test_basic_properties(self):
+        text = "cut ami for foo-bar-baz from one-two-three"
+        result = ShowPlugin._parse_cut_ami(text)
+        self.assertEqual(result, {
+            'dest_env':          'foo',
+            'dest_dep':          'bar',
+            'dest_play':         'baz',
+            'source_env':        'one',
+            'source_dep':        'two',
+            'source_play':       'three',
+            'base_ami':          None,
+            'version_overrides': None,
+            'verbose':           False,
+            'noop':              False,
+        })
+
+    def test_all_properties(self):
+        text = "verbose noop cut ami for foo-bar-baz from one-two-three using ami-deadbeef with thing=athing bang=abang"
+        result = ShowPlugin._parse_cut_ami(text)
+        self.assertEqual(result, {
+            'dest_env':          'foo',
+            'dest_dep':          'bar',
+            'dest_play':         'baz',
+            'source_env':        'one',
+            'source_dep':        'two',
+            'source_play':       'three',
+            'base_ami':          'ami-deadbeef',
+            'version_overrides': {'thing': 'athing', 'bang': 'abang'},
+            'verbose':           True,
+            'noop':              True,
+        })

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ simple-crypt==4.0.0
 python-jenkins==0.4.6
 pyparsing==2.0.5
 mock==1.3.0
+pytz==2015.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ qrcode==5.1
 pillow==2.7.0
 simple-crypt==4.0.0
 python-jenkins==0.4.6
+pyparsing==2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pillow==2.7.0
 simple-crypt==4.0.0
 python-jenkins==0.4.6
 pyparsing==2.0.5
+mock==1.3.0

--- a/tests/test_show_plugin.py
+++ b/tests/test_show_plugin.py
@@ -1,6 +1,6 @@
-# To run these, go to the `plugins` directory and run `python -m unittest discover`
+# To run these, run `python -m unittest discover` from the top of the repo
 
-from show import *
+from plugins.show import *
 from pyparsing import ParseException
 import unittest, mock
 


### PR DESCRIPTION
Implements a mini-language for "cut_from_edp", aka the "cut ami"
command that's a little more user-friendly than the previous regex-based
parsing method. Specifically, the "using" and "with" statements can now
appear in any order, as can the "verbose" and "noop" options. Also, the
mini-language uses familiar whitespace-agnostic semantics for token
separation, so things like "with configuration = master" are now valid.
Best of all, Alton will now report an error for "cut ami" commands with
invalid syntax that includes the position of the error and the
expected token.

Also removes the function supporting the old version of the "cut ami"
command.

@edx/devops 