### PR TITLE
Add html=False when /code is used with "say"

### DIFF
--- a/plugins/show.py
+++ b/plugins/show.py
@@ -64,7 +64,7 @@ class ShowPlugin(WillPlugin):
 
         ami = self._get_ami(ami_id, message=message)
         if ami:
-            self.say("/code {}".format(pformat(ami.tags)), message)
+            self.say("/code {}".format(pformat(ami.tags)), message, html=False)
 
     @respond_to("^diff "
                 "(?P<first_env>\w*)-"  # First Environment
@@ -229,7 +229,7 @@ class ShowPlugin(WillPlugin):
             )
 
             self.say(msg, message=message, color='yellow')
-            self.say(example_command, message=message, color='yellow')
+            self.say(example_command, message=message, color='yellow', html=False)
 
         self._notify_abbey(message, dest_env, dest_dep, dest_play,
                            final_versions, noop, dest_running_ami, verbose)
@@ -298,7 +298,7 @@ class ShowPlugin(WillPlugin):
         output = ["Active Plays",
                   "------------"]
         output.extend(list(plays))
-        self.say("/code {}".format("\n".join(output)), message)
+        self.say("/code {}".format("\n".join(output)), message, html=False)
 
     def _instance_elbs(self, instance_id, profile_name=None, elbs=None):
 
@@ -417,7 +417,7 @@ class ShowPlugin(WillPlugin):
                                                line[3].ljust(ami_len),))
 
         logging.error(output_table)
-        self.say("/code {}".format("\n".join(output)), message)
+        self.say("/code {}".format("\n".join(output)), message, html=False)
 
     def _get_ami_versions(self, ami_id, message=None):
         versions_dict = {}


### PR DESCRIPTION
When Alton uses "say" to communicate back to a Hipchat channel, all messages default to being rendered as HTML. When a message is send and rendered as HTML, slash commands and other special commands don't work in HipChat.

@maxrothman 