### PR TITLE
Updated the show command to handle missing instances

### DIFF
--- a/plugins/show.py
+++ b/plugins/show.py
@@ -356,6 +356,10 @@ class ShowPlugin(WillPlugin):
         }
         instances = ec2.get_all_instances(filters=edp_filter)
 
+        if not instances:
+            self.say('No instances found. The input may be misspelled.', color='red')
+            return
+
         output_table = [
             ["Internal DNS", "Versions", "ELBs", "AMI"],
             ["------------", "--------", "----", "---"],


### PR DESCRIPTION
If no instances are found, the show command will say so, rather than displaying an empty table.