### PR TITLE
For all bucket errors besides no bucket, re-raise.

### DIFF
--- a/alton/pause_event.py
+++ b/alton/pause_event.py
@@ -145,6 +145,9 @@ class S3PauseEventOps(PauseEventOps):
         except S3ResponseError as exc:
             if exc.error_code == 'NoSuchBucket':
                 self.pipeline_bucket = self.s3_conn.create_bucket(bucket_name)
+            else:
+                # In all other error cases, re-raise.
+                raise
         # Create a GoCD client for pausing/unpausing pipelines.
         self.gocd_client = GoCDAPI(gocd_username, gocd_password, gocd_url)
 


### PR DESCRIPTION
Swallowing the error is the wrong course of action. It leads to Alton giving messages like:
```
I ran into trouble running ReleasePlugin.status:

Traceback (most recent call last):
  File "/edx/app/alton/venvs/alton/local/lib/python2.7/site-packages/will/listener.py", line 170, in fn
    listener["fn"](*args, **kwargs)
  File "/edx/app/alton/venvs/alton/local/lib/python2.7/site-packages/will/decorators.py", line 6, in wrapped_f
    f(*args, **kwargs)
  File "/edx/app/alton/alton/plugins/release.py", line 154, in status
    statuses = self.pause_ops.pipeline_status(pipeline_system)
  File "/edx/app/alton/alton/alton/pause_event.py", line 422, in pipeline_status
    pause_status = self._get_current_pause_events(pipeline_system)
  File "/edx/app/alton/alton/alton/pause_event.py", line 188, in _get_current_pause_events
    for key in bucket_lister(self.pipeline_bucket, prefix=self.CURRENT_DIRECTORY):
AttributeError: 'S3PauseEventOps' object has no attribute 'pipeline_bucket'
```
when other errors occur.

