### PR TITLE
prerelease-materials should not be paused when halting a pipeline.

### DIFF
--- a/alton/pause_event.py
+++ b/alton/pause_event.py
@@ -29,7 +29,6 @@ log = logging.getLogger(__name__)
 PIPELINE_SYSTEM_INFO = {
     'edxapp': [
         'edxapp_release_advancer',
-        'prerelease_edxapp_materials_latest',
         'edxapp_cut_release_candidate'
     ]
 }


### PR DESCRIPTION
This will allow hotfixes to continue when edxapp pipeline pause events occur.