### PR TITLE
lower alton loglevel

### DIFF
--- a/config.py
+++ b/config.py
@@ -118,6 +118,6 @@ PLUGIN_BLACKLIST = [
 
 
 # Logging level
-LOGLEVEL = "INFO"
+LOGLEVEL = "WARN"
 
 TWOFACTOR_ISSUER = 'edX Alton'


### PR DESCRIPTION
FYI,  Alton is deployed like this now with a manual change in production.   I don't know who made that change, but it's keeping me from deploying with ansible.  Therefore, i'm mirroring that change here:

```
fredsmith@alton i-03c5e8b9dda4b6bbd:/edx/app/alton/alton$ git diff config.py
diff --git a/config.py b/config.py
index 7079290..c5e73c3 100644
--- a/config.py
+++ b/config.py
@@ -118,6 +118,6 @@ PLUGIN_BLACKLIST = [
 
 
 # Logging level
-LOGLEVEL = "INFO"
+LOGLEVEL = "WARN"
 
```